### PR TITLE
feat: add twitter query keys

### DIFF
--- a/bot/__main__.py
+++ b/bot/__main__.py
@@ -25,6 +25,8 @@ KNOWN_QUERY_KEYS = [
     "utm_campaign",
     "utm_content",
     "utm_term",
+	"s",
+	"t"
 ]
 
 


### PR DESCRIPTION
Adds query keys that show up when Twitter's "copy-link" feature is used to share a post.